### PR TITLE
Use forward slash in `npm compile` script to support Unix-like systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,20 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
-## [1.2.0] - 2024-2-5
+## [1.2.1] - 2025-7-13
+
+### Fixed
+
+* fix: use forward slash in `npm compile` script to support Unix-like systems (@Villy-P) — issue introduced by @ethanc8
+
+## [1.2.0] - 2024-12-5
 
 ### Changed
 
 * feat: Converted project into an `npx` script (@Villy-P)
 * chore: Simpilified Tailwind CSS Addition (@Villy-P)
 
-## [1.1.0] - 2025-2-4
+## [1.1.0] - 2025-12-4
 
 ### Changed
 

--- a/bin/src/package.json
+++ b/bin/src/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "conc \"rollup -c -w\" \"tsc --build .\\tsconfig.node.json -w\"",
+    "compile": "conc \"rollup -c -w\" \"tsc --build ./tsconfig.node.json -w\"",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "conc \"rollup -c -w\" \"tsc --build .\\tsconfig.node.json -w\"",
+    "compile": "conc \"rollup -c -w\" \"tsc --build ./tsconfig.node.json -w\"",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-webview-extension-svelte-generator",
-  "version": "1.0.1",
+  "version": "1.2.1",
   "description": "A template repository to quickly make a Visual Studio Code Webview Extension using Svelte 5 and Rollup",
   "bin": {
     "vscode-webview-extension-svelte-generator": "./bin/index.mjs"


### PR DESCRIPTION
*Fixes Issue #13*

Fixes an issue where `npm compile` would fail if run on Unix-like systems due to a backslash